### PR TITLE
chore: remove functions from db upgrade deprecated on Moodle 3.9

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -7,11 +7,5 @@ defined('MOODLE_INTERNAL') || die();
 function xmldb_auth_emailadmin_upgrade($oldversion) {
     global $CFG, $DB;
 
-    if ($oldversion < 2019070800) {
-        upgrade_fix_config_auth_plugin_names('emailadmin');
-        upgrade_fix_config_auth_plugin_defaults('emailadmin');
-        upgrade_plugin_savepoint(true, 2019070800, 'auth', 'emailadmin');
-    }
-
     return true;
 }

--- a/version.php
+++ b/version.php
@@ -26,8 +26,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2019072300;        // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires  = 2015051101;        // Requires this Moodle version.
+$plugin->version   = 2030061000;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->requires  = 2017111300;        // Requires this Moodle version.
 $plugin->component = 'auth_emailadmin';      // Full name of the plugin (used for diagnostics).
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '1.4.4';
+$plugin->release = '1.4.5';


### PR DESCRIPTION
Fixes https://github.com/hrimhari/moodle-auth_emailadmin/issues/37